### PR TITLE
Add dependency injection utilities

### DIFF
--- a/src/coyaml/__init__.py
+++ b/src/coyaml/__init__.py
@@ -23,8 +23,18 @@ Usage example:
 
 from coyaml._internal.config import YConfig
 from coyaml._internal.deps import YDeps
+from coyaml._internal.inject import ConfigKey, DepName, coyaml
 from coyaml._internal.node import YNode
 from coyaml._internal.registry import YRegistry
 from coyaml.sources.base import YSource
 
-__all__ = ['YConfig', 'YNode', 'YDeps', 'YRegistry', 'YSource']
+__all__ = [
+    'YConfig',
+    'YNode',
+    'YDeps',
+    'YRegistry',
+    'YSource',
+    'coyaml',
+    'ConfigKey',
+    'DepName',
+]

--- a/src/coyaml/_internal/inject.py
+++ b/src/coyaml/_internal/inject.py
@@ -1,0 +1,67 @@
+"""Utilities for dependency injection."""
+
+from __future__ import annotations
+
+import inspect
+from functools import wraps
+from typing import Annotated, Any, get_args, get_origin, get_type_hints
+
+from pydantic import BaseModel
+
+from coyaml._internal.node import YNode
+from coyaml._internal.registry import YRegistry
+
+
+class ConfigKey:
+    """Metadata for injecting a value from :class:`YConfig`."""
+
+    def __init__(self, path: str, key: str = 'default') -> None:
+        self.path = path
+        self.key = key
+
+
+class DepName:
+    """Metadata for injecting a dependency from :class:`YDeps`."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def coyaml(func):
+    """Decorator that injects parameters based on ``Annotated`` hints."""
+
+    hints = get_type_hints(func, include_extras=True)
+    sig = inspect.signature(func)
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        bound = sig.bind_partial(*args, **kwargs)
+        for name, _param in sig.parameters.items():
+            if name in bound.arguments:
+                continue
+
+            hint = hints.get(name)
+            if hint is None:
+                continue
+
+            if get_origin(hint) is Annotated:
+                typ, *meta = get_args(hint)
+                for m in meta:
+                    if isinstance(m, ConfigKey):
+                        cfg = YRegistry.get_config(m.key)
+                        value = cfg[m.path]
+                        if (
+                            isinstance(value, YNode)
+                            and isinstance(typ, type)
+                            and issubclass(typ, BaseModel)
+                        ):
+                            value = value.to(typ)
+                        bound.arguments[name] = value
+                        break
+                    elif isinstance(m, DepName):
+                        deps = YRegistry.get_deps()
+                        bound.arguments[name] = deps.get(m.name)
+                        break
+        return func(*bound.args, **bound.kwargs)
+
+    return wrapper

--- a/src/coyaml/_internal/registry.py
+++ b/src/coyaml/_internal/registry.py
@@ -4,6 +4,7 @@ import threading
 from typing import Any
 
 from coyaml._internal.config import YConfig
+from coyaml._internal.deps import YDeps
 from coyaml.sources.base import YSource
 
 
@@ -18,6 +19,7 @@ class YRegistry:
     _instances: dict[str, YConfig] = {}
     _lock = threading.Lock()
     _scheme_map: dict[str, Any] = {}  # scheme -> YSource subclass or factory func
+    _deps: YDeps | None = None
 
     @classmethod
     def register_scheme(cls, scheme: str, handler: Any) -> None:
@@ -54,6 +56,18 @@ class YRegistry:
             if key not in cls._instances:
                 raise KeyError(f"Config '{key}' not found")
             return cls._instances[key]
+
+    @classmethod
+    def set_deps(cls, deps: YDeps) -> None:
+        """Store a YDeps container for dependency providers."""
+        cls._deps = deps
+
+    @classmethod
+    def get_deps(cls) -> YDeps:
+        """Retrieve stored YDeps container."""
+        if cls._deps is None:
+            raise KeyError('Dependencies container not set')
+        return cls._deps
 
     @classmethod
     def create_from_uri_list(


### PR DESCRIPTION
## Summary
- add ConfigKey and DepName metadata classes
- create coyaml decorator to inject dependencies
- expose coyaml utilities in public API
- extend YRegistry with dependency container support

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
