### PR TITLE
v0.10.3

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -43,6 +43,15 @@ jobs:
         run: |
           uv run pytest --cov=coyaml --cov-report=lcov:coverage/lcov.info
 
+      - name: Test build
+        run: |
+          uv build --wheel
+          uv build --sdist
+          echo "Checking wheel contents:"
+          unzip -l dist/*.whl
+          echo "Checking sdist contents:"
+          tar -tzf dist/*.tar.gz
+
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,12 @@ jobs:
 
       - name: Build distributions
         run: |
-          uv build
+          uv build --wheel
+          uv build --sdist
+          echo "Checking wheel contents:"
+          unzip -l dist/*.whl
+          echo "Checking sdist contents:"
+          tar -tzf dist/*.tar.gz
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.10.3] - 2025-01-27
+
+### Fixed
+- Fixed GitHub Actions build process: changed from `uv build` to `uv build --wheel` and `uv build --sdist` for direct building
+- Added build verification steps in CI/CD to check wheel and sdist contents
+- Ensured both wheel and source distributions contain all Python files
+
 ## [v0.10.2] - 2025-01-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coyaml"
-version = "0.10.2"
+version = "0.10.3"
 description = "Yaml configuration library for python"
 authors = [{ name = "Petr Matyukov", email = "kuruhuru@gmail.com" }]
 
@@ -31,6 +31,7 @@ include = [
     "src/coyaml/__init__.pyi",
     "src/coyaml/**/*.pyi",
     "src/coyaml/py.typed",
+    "src/coyaml/**/*.py",
 ]
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
## [v0.10.3] - 2025-01-27

### Fixed
- Fixed GitHub Actions build process: changed from `uv build` to `uv build --wheel` and `uv build --sdist` for direct building
- Added build verification steps in CI/CD to check wheel and sdist contents
- Ensured both wheel and source distributions contain all Python files